### PR TITLE
Fix version conflicts caused by PR#82

### DIFF
--- a/EnhancedBatch/EnhancedBatch.csproj
+++ b/EnhancedBatch/EnhancedBatch.csproj
@@ -9,9 +9,9 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Graph" Version="1.16.0" />
+    <PackageReference Include="Microsoft.Graph" Version="3.35.0" />
     <PackageReference Include="Microsoft.Graph.Auth" Version="1.0.0-preview.0" />
-    <PackageReference Include="Microsoft.Graph.Core" Version="1.16.0" />
+    <PackageReference Include="Microsoft.Graph.Core" Version="1.25.1" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.2.1" />
   </ItemGroup>
 


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump Microsoft.Graph from 1.16.0 to 3.35.0. [(PR#82)](https://github.com/andrueastman/BatchSample/pull/82).
Hope this fix can help you.

Best regards,
sucrose